### PR TITLE
remove recipe from ALL lists

### DIFF
--- a/components/RecipeCard.js
+++ b/components/RecipeCard.js
@@ -1,4 +1,4 @@
-import { addRecipe, addRecipebyList, checkFavorite, removeRecipe, removeRecipebyList } from './UserLocalStorage.js';
+import { addRecipe, addRecipebyList, checkFavorite, removeRecipebyList } from './UserLocalStorage.js';
 
 const link = document.createElement('link');
 link.rel = 'stylesheet';
@@ -219,16 +219,15 @@ class RecipeCard extends HTMLElement {
         console.log('Prompting user to add to favorites lists');
       } else {
         this.isFavorite = false;
-        removeRecipe(this.getAttribute('recipe-id'));
-        // eslint-disable-next-line no-undef
+        const containers = this.shadow.querySelectorAll('.container');
+        // goes through all the lists and removes the recipe if it is found
         for (let i = 0; i < containers.length; i += 1) {
-          // eslint-disable-next-line no-undef
-          console.log(containers[i].textContent);
-          // eslint-disable-next-line no-undef
-          removeRecipebyList(containers[i].textContent, this.getAttribute('recipe-id'));
+          removeRecipebyList(containers[i].querySelector('span').innerHTML, this.getAttribute('recipe-id'));
         }
         favoriteIcon.src = '../assets/favorite.svg';
         console.log('Remove item from ALL favorites lists here');
+        /* Reload the page as a shortcut for showing updated lists */
+        location.reload();
       }
     });
 

--- a/components/UserLocalStorage.js
+++ b/components/UserLocalStorage.js
@@ -109,7 +109,7 @@ export function addRecipebyList(listName, recipeID) {
       return;
     }
   }
-  array.push(recipeID);
+  array.push(parseInt(recipeID, 10));
   storage.setItem(listName, JSON.stringify(array));
 }
 

--- a/scripts/recipe.js
+++ b/scripts/recipe.js
@@ -2,7 +2,7 @@
  * Handles the recipe page functionality. Recipe page is when the user clicks on a recipe and the actual full page with all information
  * pulls up for it.
  */
-import { addRecipe, addRecipebyList, checkFavorite, removeRecipe, removeRecipebyList } from '../components/UserLocalStorage.js';
+import { addRecipe, addRecipebyList, checkFavorite, removeRecipebyList } from '../components/UserLocalStorage.js';
 import apiKey from './apikey.js';
 
 const tokenKey = `?apiKey=${apiKey}`;
@@ -193,11 +193,10 @@ async function init() {
       showDropdown(recipe, isMobile);
     } else {
       isFavorite = false;
-      removeRecipe(recipe.id);
       const containers = document.querySelectorAll('.container');
+      // goes through all the lists and deletes if it is in list
       for (let i = 0; i < containers.length; i += 1) {
-        console.log(containers[i].textContent);
-        removeRecipebyList(containers[i].textContent, recipe.id);
+        removeRecipebyList(containers[i].querySelector('span').innerHTML, recipe.id);
       }
       favoriteIcon.src = '../assets/favorite.svg';
     }


### PR DESCRIPTION
Resolves #179 #134 #236 

**What were your changes**

Modified UserLocalStorage.js because it was adding quotes around the recipes to all lists except favorites-masters

Updated RecipeCard.js to go through all the lists and look for the recipe id (i think it has to search since the checkmarks are saved to reflect where the recipe is) and it deletes it from the list if its in the list

**What specifically should be checked**

That a recipe is deleted from all lists when you unheart it and it reloads every time on homepage and favorites page and on anypage
